### PR TITLE
add promisify

### DIFF
--- a/templates/standard/template/src/app.wpy
+++ b/templates/standard/template/src/app.wpy
@@ -41,6 +41,7 @@ export default class extends wepy.app {
   constructor () {
     super()
     this.use('requestfix')
+    this.use('promisify')
   }
 
   onLaunch() {


### PR DESCRIPTION
初始化Promise，避免使用`request(url).then()`时出现`then of undefined`的错误