### PR TITLE
remove the aliasFields config for the standard template

### DIFF
--- a/templates/standard/template/wepy.config.js
+++ b/templates/standard/template/wepy.config.js
@@ -19,6 +19,7 @@ module.exports = {
       counter: path.join(__dirname, 'src/components/counter'),
       '@': path.join(__dirname, 'src')
     },
+    aliasFields: ['wepy', 'weapp'],
     modules: ['node_modules']
   },
   compilers: {

--- a/templates/standard/template/wepy.config.js
+++ b/templates/standard/template/wepy.config.js
@@ -19,7 +19,6 @@ module.exports = {
       counter: path.join(__dirname, 'src/components/counter'),
       '@': path.join(__dirname, 'src')
     },
-    aliasFields: ['wepy'],
     modules: ['node_modules']
   },
   compilers: {


### PR DESCRIPTION
Use the default config instead.

Or maybe `['wepy', 'weapp']`?