### PR TITLE
fix dependency for the redux template

### DIFF
--- a/templates/standard/template/package.json
+++ b/templates/standard/template/package.json
@@ -29,7 +29,7 @@
     "miniprogram-slide-view": "0.0.3"
   },
   "devDependencies": {
-    "@wepy/cli": "^2.0.0-alpha.10",
+    "@wepy/cli": "^2.0.0-alpha.13",
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@wepy/babel-plugin-import-regenerator": "0.0.2",

--- a/templates/standard/template/package.json
+++ b/templates/standard/template/package.json
@@ -29,7 +29,7 @@
     "miniprogram-slide-view": "0.0.3"
   },
   "devDependencies": {
-    "@wepy/cli": "^2.0.0-alpha.13",
+    "@wepy/cli": "^2.0.0-alpha.20",
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@wepy/babel-plugin-import-regenerator": "0.0.2",


### PR DESCRIPTION
In @wepy/cli 2.0.0-alpha.13, a bug is fixed 
https://github.com/Tencent/wepy/commit/d54f8b2e6089bd332da06a2d7485eca3df8d2425#diff-668fc4204b978bf81fa9644da8534c43

If not updating the version, will meet a bug:
VM150:1 thirdScriptError 
 sdk uncaught third Error 
 Cannot read property 'prototype' of undefined 
 TypeError: Cannot read property 'prototype' of undefined
    at runInContext (http://127.0.0.1:39537/appservice/vendor.js:6489:28)
    at Object.<anonymous> (http://127.0.0.1:39537/appservice/vendor.js:22148:11)
    at Object.<anonymous> (http://127.0.0.1:39537/appservice/vendor.js:22175:3)
    at __wepy_require (http://127.0.0.1:39537/appservice/vendor.js:20:26)
    at Object.<anonymous> (http://127.0.0.1:39537/appservice/vendor.js:4148:15)
    at __wepy_require (http://127.0.0.1:39537/appservice/vendor.js:20:26)
    at Object.<anonymous> (http://127.0.0.1:39537/appservice/vendor.js:4060:27)
    at __wepy_require (http://127.0.0.1:39537/appservice/vendor.js:20:26)
    at http://127.0.0.1:39537/appservice/store/index.js:10:67
    at require (http://127.0.0.1:39537/appservice/__dev__/WAService.js:19:7304)